### PR TITLE
only call promisify() once

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@
 var wrappers = require('pouchdb-wrappers');
 var nodify = require('promise-nodify');
 var Promise = require('bluebird');
-var getSize = require('get-folder-size');
+var getSize = Promise.promisify(require('get-folder-size'));
 
 exports.installSizeWrapper = function () {
   var db = this;
@@ -58,7 +58,7 @@ exports.getDiskSize = function (callback) {
       return cb();
     };
     promise = then.call(db, function () {
-      return getDBSize(path);
+      return getSize(path);
     });
   } else {
     var msg = "Can't get the database size for database type '" + db.type() + "'!";
@@ -68,7 +68,3 @@ exports.getDiskSize = function (callback) {
   nodify(promise, callback);
   return promise;
 };
-
-function getDBSize(path) {
-  return Promise.promisify(getSize)(path);
-}


### PR DESCRIPTION
While profiling express-pouchdb, I noticed that `bluebird.promisify` was taking up an exceptional amount of self-time:

![screenshot from 2015-08-09 17 32 54](https://cloud.githubusercontent.com/assets/283842/9157059/b0a7511a-3ebc-11e5-998a-87a6a4cbc1b5.png)


This PR should fix that. We only need to call `promisify` once.